### PR TITLE
Updated IsDroidInRange routine to correctly calculate whether a droid is in range

### DIFF
--- a/src/net/obviam/bt/ai/IsDroidInRange.java
+++ b/src/net/obviam/bt/ai/IsDroidInRange.java
@@ -28,6 +28,6 @@ public class IsDroidInRange extends Routine {
 
     private boolean isInRange(Droid droid, Droid enemy) {
         return (Math.abs(droid.getX() - enemy.getX()) <= droid.getRange()
-                || Math.abs(droid.getY() - enemy.getY()) < droid.getRange());
+                && Math.abs(droid.getY() - enemy.getY()) <= droid.getRange());
     }
 }


### PR DESCRIPTION
The routine would falsely report that two droids were in range of each other if the difference in their Y coordinates were less than the droid's range.

So one droid at `[10, 5]` and another at `[1, 5]` both with a range of `2` would be reported to be in range of each other their two Y values are less than the droid's range.
